### PR TITLE
Fix sanitizeInput script tag check

### DIFF
--- a/middlewares/secure/sanitizeInput.js
+++ b/middlewares/secure/sanitizeInput.js
@@ -9,7 +9,7 @@ export const sanitizeInput = async (ctx, next) => {
     // Rechazo mensajes vacíos o peligrosos
     const text = incomingText.trim()
 
-    if (text.length === 0 || text.includes('<scrip>')) {
+    if (text.length === 0 || text.includes('<script>')) {
       return ctx.reply(
         '🫸🏽 Entrada inválida. Inténtalo de nuevo con texto válido.'
       )


### PR DESCRIPTION
## Summary
- fix sanitizeInput check to detect `<script>` tag

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684343fefd788320817185cc74bf7e00