### PR TITLE
Fix console error typo

### DIFF
--- a/config/MongoDB/db.js
+++ b/config/MongoDB/db.js
@@ -7,7 +7,7 @@ const connectDB = async () => {
     console.log(`👾 MongoDB conectando en: ${mongoose.connection.host}`)
   } catch (error) {
     console.error(
-      `🦽 Nos está fallando la conexión a MOngoDB: ${error.message}`
+      `🦽 Nos está fallando la conexión a MongoDB: ${error.message}`
     )
     process.exit(1)
   }


### PR DESCRIPTION
## Summary
- correct typo `MOngoDB` -> `MongoDB` in database error log

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684343f959e48320bfa92392461d5014