### PR TITLE
Fix sanitizeInput check

### DIFF
--- a/middlewares/secure/sanitizeInput.js
+++ b/middlewares/secure/sanitizeInput.js
@@ -9,7 +9,7 @@ export const sanitizeInput = async (ctx, next) => {
     // Rechazo mensajes vacíos o peligrosos
     const text = incomingText.trim()
 
-    if (text.length === 0 || text.includes('<scrip>')) {
+    if (text.length === 0 || text.includes('<script>')) {
       return ctx.reply(
         '🫸🏽 Entrada inválida. Inténtalo de nuevo con texto válido.'
       )


### PR DESCRIPTION
## Summary
- fix HTML script tag validation in sanitizeInput middleware

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684339b916a4832085d7133486cd8367