### PR TITLE
Fix message handler exit preventing /edit command

### DIFF
--- a/actions/addAction/messageHandler.js
+++ b/actions/addAction/messageHandler.js
@@ -2,10 +2,10 @@ import { detectAndParseDate } from '../../helpers/taskHelpers/date/detectAndPars
 import { buildAddMenu } from '../../helpers/taskHelpers/add/interactiveFlowAdd.js'
 
 export function registerMessageHandler(bot) {
-  bot.on('message', async (ctx) => {
+  bot.on('message', async (ctx, next) => {
     const { flowType, awaiting, pendingTask, menuMessageId } = ctx.session
     if (flowType !== 'add' || !awaiting || !ctx.message?.text) {
-      return
+      return typeof next === 'function' ? next() : undefined
     }
 
     const text = ctx.message.text.trim()


### PR DESCRIPTION
## Summary
- allow `bot.on('message')` in add flow to call `next()` for unrelated commands

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843484eec3c83209f561c4796c10999