### PR TITLE
Fix menu update when previous message missing

### DIFF
--- a/actions/addAction/fieldActions.js
+++ b/actions/addAction/fieldActions.js
@@ -29,13 +29,27 @@ export function registerFieldActions(bot) {
         // Simplemente mostramos/EDITAMOS el menú
         ctx.session.awaiting = null
         const { text, markup } = buildAddMenu(ctx.session.pendingTask)
-        return ctx.telegram.editMessageText(
-          ctx.chat.id,
-          ctx.session.menuMessageId,
-          null,
-          text,
-          { parse_mode: 'Markdown', ...markup }
-        )
+        let targetId =
+          ctx.session.menuMessageId ?? ctx.callbackQuery?.message?.message_id
+
+        if (!targetId) {
+          const newMsg = await ctx.reply(text, markup)
+          ctx.session.menuMessageId = newMsg.message_id
+          return
+        }
+
+        try {
+          await ctx.telegram.editMessageText(
+            ctx.chat.id,
+            targetId,
+            null,
+            text,
+            { parse_mode: 'Markdown', ...markup }
+          )
+        } catch {
+          const newMsg = await ctx.reply(text, markup)
+          ctx.session.menuMessageId = newMsg.message_id
+        }
       } else {
         // Entramos en modo force-reply para rellenar este campo
         ctx.session.awaiting = key

--- a/actions/addAction/messageHandler.js
+++ b/actions/addAction/messageHandler.js
@@ -55,12 +55,25 @@ export function registerMessageHandler(bot) {
 
     // Editamos el menú en el mismo mensaje
     const { text: menuText, markup } = buildAddMenu(pendingTask)
-    return ctx.telegram.editMessageText(
-      ctx.chat.id,
-      menuMessageId,
-      null,
-      menuText,
-      { parse_mode: 'Markdown', ...markup }
-    )
+    let targetId = menuMessageId
+
+    if (!targetId) {
+      const newMsg = await ctx.reply(menuText, { parse_mode: 'Markdown', ...markup })
+      ctx.session.menuMessageId = newMsg.message_id
+      return
+    }
+
+    try {
+      await ctx.telegram.editMessageText(
+        ctx.chat.id,
+        targetId,
+        null,
+        menuText,
+        { parse_mode: 'Markdown', ...markup }
+      )
+    } catch {
+      const newMsg = await ctx.reply(menuText, { parse_mode: 'Markdown', ...markup })
+      ctx.session.menuMessageId = newMsg.message_id
+    }
   })
 }


### PR DESCRIPTION
## Summary
- handle missing message id in add action field handlers
- apply same fallback logic in message handler

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: @eslint/js missing)*

------
https://chatgpt.com/codex/tasks/task_e_68434fe2fc288320a3e61f1bb0d002fe