### PR TITLE
Allow select_edit callbacks in flowGuard

### DIFF
--- a/middlewares/flowControl/flowGuard.js
+++ b/middlewares/flowControl/flowGuard.js
@@ -40,7 +40,11 @@ export async function flowGuard(ctx, next) {
       case 'edit':
       case 'delete':
       case 'complete':
-        if (new RegExp(`^${flowType}_`).test(cb)) {
+        if (
+          flowType === 'edit'
+            ? /^(edit_|select_edit_)/.test(cb)
+            : new RegExp(`^${flowType}_`).test(cb)
+        ) {
           return next()
         }
         break


### PR DESCRIPTION
## Summary
- update flowGuard to allow `select_edit` callbacks while editing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843849945408320a23a5d3768dda540