### PR TITLE
Replace edit action handler with registerTaskSelector

### DIFF
--- a/actions/editAction/startEditAction.js
+++ b/actions/editAction/startEditAction.js
@@ -54,10 +54,7 @@ export function registerStartEditAction(bot) {
   })
 
   // ✅ Flujo cuando el usuario elige una tarea para editar
-  bot.action(/^select_edit_(.+)$/, async (ctx) => {
-    await ctx.answerCbQuery()
-
-    const task = await registerTaskSelector.resolve(ctx)
+  registerTaskSelector(bot, 'select_edit', async (ctx, task) => {
     ctx.session.flowType = 'edit'
     ctx.session.editing = { id: task._id, oldName: task.name }
     ctx.session.edits = {}
@@ -65,7 +62,6 @@ export function registerStartEditAction(bot) {
     ctx.session.timezone = await getUserTimezone(ctx.from.id)
 
     const { text, markup } = buildEditMenu(task, ctx.session.timezone, false)
-
     try {
       await ctx.telegram.editMessageText(
         ctx.chat.id,


### PR DESCRIPTION
## Summary
- switch the edit task selection handler to use `registerTaskSelector`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843865b66a08320bb28bb351c52f96e