### PR TITLE
Improve edit flow icons

### DIFF
--- a/actions/addAction/confirmAction.js
+++ b/actions/addAction/confirmAction.js
@@ -37,9 +37,9 @@ export function registerConfirmAction(bot) {
     return delayReply(
       ctx,
       'Tarea creada:\n' +
-        `• Nombre: ${task.name}\n` +
-        `• Descripción: ${task.description}\n` +
-        `• Fecha: ${formatDateEs(task.reminderAt, timezone)}`
+        `🔺 Nombre: ${task.name}\n` +
+        `🔸 Descripción: ${task.description}\n` +
+        `🔹 Fecha: ${formatDateEs(task.reminderAt, timezone)}`
     )
   })
 }

--- a/actions/editAction/saveEditAction.js
+++ b/actions/editAction/saveEditAction.js
@@ -21,7 +21,7 @@ export function registerSaveEditAction(bot) {
       await task.save()
       await delayReply(
         ctx,
-        `✅ Tarea guardada:\n${changes.map((c) => `• ${c}`).join('\n')}`,
+        `👌🏽 Tarea guardada:\n${changes.join('\n')}`,
         { parse_mode: 'HTML' }
       )
     } else {

--- a/events/editForceReply/editForceReplyHandler.js
+++ b/events/editForceReply/editForceReplyHandler.js
@@ -83,7 +83,7 @@ export function registerForceReplyHandler(bot) {
       }
 
       ctx.session.edits = { ...edits, ...fields }
-      const summary = changes.map((c) => ` • ${c}`).join('\n')
+      const summary = changes.join('\n')
 
       await ctx.reply(`Cambio aplicado:\n${summary}`, { parse_mode: 'HTML' })
 

--- a/helpers/taskHelpers/edit/updateTaskFields.js
+++ b/helpers/taskHelpers/edit/updateTaskFields.js
@@ -27,14 +27,14 @@ export const updateTaskFields = (
   if (newName && newName !== task.name) {
     task.name = newName
     updated = true
-    changes.push(`<b>Nuevo nombre:</b> ${escapeHtml(newName)}`)
+    changes.push(`🔺 <b>Nuevo nombre:</b> ${escapeHtml(newName)}`)
   }
 
   // Cambiar descripción
   if (newDescription && newDescription !== task.description) {
     task.description = newDescription
     updated = true
-    changes.push(`<b>Descripción:</b> ${escapeHtml(newDescription)}`)
+    changes.push(`🔸 <b>Nueva descripción:</b> ${escapeHtml(newDescription)}`)
   }
 
   // Cambiar fecha de recordatorio
@@ -45,7 +45,7 @@ export const updateTaskFields = (
     task.reminderAt = date
     updated = true
     const formatted = formatDateEs(date, timezone)
-    changes.push(`<b>Nueva fecha:</b> ${escapeHtml(formatted)}`)
+    changes.push(`🔹 <b>Nueva fecha:</b> ${escapeHtml(formatted)}`)
   }
 
   return { updated, changes }


### PR DESCRIPTION
## Summary
- update save edit action text to use the hand emoji
- add icons to updateTaskFields summaries
- keep icons consistent in edit force reply handler
- show icons when confirming task creation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438b159c908320bd950a3a6d880742