### PR TITLE
Implement flash messages for bot commands

### DIFF
--- a/actions/addAction/confirmAction.js
+++ b/actions/addAction/confirmAction.js
@@ -1,6 +1,6 @@
 import { safeAnswerCbQuery } from '../../utils/retryUtils/safeAnswerCbQuery.js'
 import { safeEditMessageReplyMarkup } from '../../utils/retryUtils/safeEditMessageReplyMarkup.js'
-import { delayReply } from '../../utils/delayUtils/delayReply.js'
+import { flashReply } from '../../utils/delayUtils/flashReply.js'
 import { Task } from '../../models/task.js'
 import { formatDateEs } from '../../helpers/taskHelpers/date/formatDateEs.js'
 import { getUserTimezone } from '../../helpers/taskHelpers/timezone/userTimezone/getUserTimezone.js'
@@ -34,12 +34,6 @@ export function registerConfirmAction(bot) {
     delete ctx.session.pendingTask
     delete ctx.session.menuMessageId
 
-    return delayReply(
-      ctx,
-      'Tarea creada:\n' +
-        `🔺 Nombre: ${task.name}\n` +
-        `🔸 Descripción: ${task.description}\n` +
-        `🔹 Fecha: ${formatDateEs(task.reminderAt, timezone)}`
-    )
+    return flashReply(ctx, '👌🏽 Tarea creada')
   })
 }

--- a/actions/clearAction/clearActionHandler.js
+++ b/actions/clearAction/clearActionHandler.js
@@ -1,5 +1,5 @@
 import { Task } from '../../models/task.js'
-import { delayReply } from '../../utils/delayUtils/delayReply.js'
+import { flashReply } from '../../utils/delayUtils/flashReply.js'
 import { safeAnswerCbQuery } from '../../utils/retryUtils/safeAnswerCbQuery.js'
 import { safeEditMessageReplyMarkup } from '../../utils/retryUtils/safeEditMessageReplyMarkup.js'
 
@@ -30,11 +30,7 @@ export function registerClearActions(bot) {
     ctx.session.pendingClearToken = null
 
     // 5) Mensaje final con delay
-    return delayReply(
-      ctx,
-      `🗑️ Se han eliminado ${result.deletedCount} tarea(s).`,
-      500
-    )
+    return flashReply(ctx, '👌🏽 Tareas eliminadas')
   })
 
   // 2) Confirma “no”
@@ -43,6 +39,6 @@ export function registerClearActions(bot) {
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingClearToken = null
-    return delayReply(ctx, 'Operación cancelada.', 500)
+    return flashReply(ctx, 'Operación cancelada.')
   })
 }

--- a/actions/completeAction/completeActionHandler.js
+++ b/actions/completeAction/completeActionHandler.js
@@ -1,6 +1,6 @@
 // actions/completeAction/completeActionHandlers.js
 import { Task } from '../../models/task.js'
-import { delayReply } from '../../utils/delayUtils/delayReply.js'
+import { flashReply } from '../../utils/delayUtils/flashReply.js'
 import { buildConfirmCompleteMenu } from '../../helpers/taskHelpers/Complete/interactiveFlowComplete.js'
 import { safeReply } from '../../utils/retryUtils/safeReply.js'
 import { safeAnswerCbQuery } from '../../utils/retryUtils/safeAnswerCbQuery.js'
@@ -44,7 +44,7 @@ export function registerCompleteActions(bot) {
     ctx.session.flowType = null
     ctx.session.pendingComplete = null
 
-    return delayReply(ctx, 'Tarea completada correctamente.', 500)
+    return flashReply(ctx, '👌🏽 Tarea completada')
   })
 
   // 3 Confirma “No”
@@ -54,6 +54,6 @@ export function registerCompleteActions(bot) {
     ctx.session.flowType = null
     ctx.session.pendingComplete = null
 
-    return delayReply(ctx, 'Operación cancelada.', 500)
+    return flashReply(ctx, 'Operación cancelada.')
   })
 }

--- a/actions/deleteAction/deleteActionHandlers.js
+++ b/actions/deleteAction/deleteActionHandlers.js
@@ -1,6 +1,6 @@
 // actions/deleteAction/deleteActionHandlers.js
 import { Task } from '../../models/task.js'
-import { delayReply } from '../../utils/delayUtils/delayReply.js'
+import { flashReply } from '../../utils/delayUtils/flashReply.js'
 import { buildConfirmDeleteMenu } from '../../helpers/taskHelpers/delete/interactiveFlowDelete.js'
 import { safeReply } from '../../utils/retryUtils/safeReply.js'
 import { safeAnswerCbQuery } from '../../utils/retryUtils/safeAnswerCbQuery.js'
@@ -39,7 +39,7 @@ export function registerDeleteActions(bot) {
     ctx.session.flowType = null
     ctx.session.pendingDelete = null
 
-    return delayReply(ctx, '🗑️ Tarea eliminada correctamente.', 500)
+    return flashReply(ctx, '👌🏽 Tarea eliminada')
   })
 
   // 3) Confirmación “No”
@@ -49,6 +49,6 @@ export function registerDeleteActions(bot) {
     ctx.session.flowType = null
     ctx.session.pendingDelete = null
 
-    return delayReply(ctx, 'Operación cancelada.', 500)
+    return flashReply(ctx, 'Operación cancelada.')
   })
 }

--- a/actions/editAction/saveEditAction.js
+++ b/actions/editAction/saveEditAction.js
@@ -1,6 +1,6 @@
 import { safeAnswerCbQuery } from '../../utils/retryUtils/safeAnswerCbQuery.js'
 import { safeEditMessageReplyMarkup } from '../../utils/retryUtils/safeEditMessageReplyMarkup.js'
-import { delayReply } from '../../utils/delayUtils/delayReply.js'
+import { flashReply } from '../../utils/delayUtils/flashReply.js'
 import { updateTaskFields } from '../../helpers/taskHelpers/edit/updateTaskFields.js'
 import { Task } from '../../models/task.js'
 
@@ -19,13 +19,9 @@ export function registerSaveEditAction(bot) {
     )
     if (updated) {
       await task.save()
-      await delayReply(
-        ctx,
-        `👌🏽 Tarea guardada:\n${changes.join('\n')}`,
-        { parse_mode: 'HTML' }
-      )
+      await flashReply(ctx, '👌🏽 Tarea editada')
     } else {
-      await delayReply(ctx, 'ℹ️ No hubo cambios.', { parse_mode: 'HTML' })
+      await flashReply(ctx, 'ℹ️ No hubo cambios.', { parse_mode: 'HTML' })
     }
 
     // limpiamos todo

--- a/actions/timezoneAction/timezoneActionHandlers.js
+++ b/actions/timezoneAction/timezoneActionHandlers.js
@@ -4,7 +4,7 @@ import { safeEditMessageReplyMarkup } from '../../utils/retryUtils/safeEditMessa
 import { safeAnswerCbQuery } from '../../utils/retryUtils/safeAnswerCbQuery.js'
 
 import { AuthorizedUser } from '../../models/authorizedUser.js'
-import { delayReply } from '../../utils/delayUtils/delayReply.js'
+import { flashReply } from '../../utils/delayUtils/flashReply.js'
 
 export function registerTimezoneActions(bot) {
   // Paso 1: elijo zona y pido confirmación
@@ -48,19 +48,11 @@ export function registerTimezoneActions(bot) {
     ctx.session.pendingTz = null
 
     if (!updatedUser) {
-      return delayReply(
-        ctx,
-        '🥸 No estás autorizado para usar este bot.',
-        { parse_mode: 'HTML' },
-        800
-      )
+      return flashReply(ctx, '🥸 No estás autorizado para usar este bot.', {
+        parse_mode: 'HTML'
+      })
     }
-    return delayReply(
-      ctx,
-      `🌐 Tu zona horaria ha sido guardada como: <b>${tz}</b>`,
-      { parse_mode: 'HTML' },
-      800
-    )
+    return flashReply(ctx, '🛫 zona cambiada')
   })
 
   // Paso 2b: confirma “No”
@@ -69,11 +61,8 @@ export function registerTimezoneActions(bot) {
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingTz = null
-    return delayReply(
-      ctx,
-      'Cambio de zona horaria cancelado.',
-      { parse_mode: 'HTML' },
-      800
-    )
+    return flashReply(ctx, 'Cambio de zona horaria cancelado.', {
+      parse_mode: 'HTML'
+    })
   })
 }

--- a/controllers/taskControllers/listTask.js
+++ b/controllers/taskControllers/listTask.js
@@ -2,6 +2,7 @@ import { Task } from '../../models/task.js'
 import { isUserAuthorized } from '../../helpers/userAuthorizedTaskController/isUserAuthorized.js'
 import { replyMessages } from '../../helpers/replyMessages/genericReplyMessages.js'
 import { safeReply } from '../../utils/retryUtils/safeReply.js'
+import { flashReply } from '../../utils/delayUtils/flashReply.js'
 
 /**
  * Controlador para manejar las tareas activas del usuario /list
@@ -29,6 +30,7 @@ export const listTasks = async (ctx) => {
   ])
 
   // 4. Enviar mensaje con inline keyboard usando safeReply
+  await flashReply(ctx, 'Aquí tienes la lista')
   return safeReply(ctx, 'Selecciona una tarea para ver sus detalles:', {
     reply_markup: { inline_keyboard: buttons }
   })

--- a/utils/delayUtils/flashReply.js
+++ b/utils/delayUtils/flashReply.js
@@ -1,0 +1,20 @@
+import { sleep } from './sleep.js'
+import { safeReply } from '../retryUtils/safeReply.js'
+
+/**
+ * Sends a temporary reply that is deleted after a delay.
+ *
+ * @param {import('telegraf').Context} ctx - Bot context
+ * @param {string} text - Message text
+ * @param {object} opts - Options for ctx.reply
+ * @param {number} ms - Time in ms before deleting the message
+ */
+export const flashReply = async (ctx, text, opts = {}, ms = 1500) => {
+  const msg = await safeReply(ctx, text, opts)
+  await sleep(ms)
+  try {
+    await ctx.telegram.deleteMessage(ctx.chat.id, msg.message_id)
+  } catch {
+    // ignore deletion errors
+  }
+}


### PR DESCRIPTION
## Summary
- add `flashReply` helper to send temporary messages
- update actions to use flash replies when confirming add/edit/delete/complete/clear operations and timezone changes
- show short notification when listing tasks

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find eslint configs)*

------
https://chatgpt.com/codex/tasks/task_e_684390ecdf148320bce6ff073cd07835