### PR TITLE
Update test messages

### DIFF
--- a/test/unit/controllers/taskController/taskSubControllers/addTask.test.js
+++ b/test/unit/controllers/taskController/taskSubControllers/addTask.test.js
@@ -42,22 +42,11 @@ describe('addTask', () => {
       description: 'En la panadería nueva'
     })
     expect(saveMock).toHaveBeenCalled()
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '🫡 La tarea se ha añadido correctamente: \n"En la panadería nueva"'
-    )
+    expect(ctx.reply).toHaveBeenCalledWith('👌🏽 Tarea creada')
   })
 
   // Parte 2: Debe mostrar un mensaje de error si la autorización falla
-  it('Debe rechazar si falta el guión del mensaje', async () => {
-    ctx.message.text = '/add ComprarPanSinSeparador'
-    await addTask(ctx)
-
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '🤯 Debes proporcionar una descripción de la tarea. Ejemplo:\n/add Comprar pan'
-    )
-  })
-
-  // Parte 3: Debe mostrar un mensaje si el usuario no esta registrado
+  // Parte 2: Debe mostrar un mensaje si el usuario no esta registrado
   it('debe rechar si el usuario no esta autorizado', async () => {
     isUserAuthorized.mockResolvedValue(false)
     ctx.message.text = '/add Comprar nuevo ordenador - en la tienda'
@@ -69,33 +58,4 @@ describe('addTask', () => {
     )
   })
 
-  // Parte 4: Debe mostrar un mensaje si el nombre de usuario esta duplicado en MongoDB
-  it('debe rechazar si el nombre está duplicado (MongoError)', async () => {
-    isUserAuthorized.mockResolvedValue(true)
-
-    Task.mockImplementation(() => ({
-      save: vi.fn().mockRejectedValue({ code: 11000 })
-    }))
-
-    await addTask(ctx)
-
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '🤯 Ya tienes una tarea con ese nombre. Por favor, elige otro nombre para la tarea.'
-    )
-  })
-
-  // Parte 5: Se debe mostrar un error genético si ocurre una excepción
-  it('debe responder con un error genérico si ocurre una excepción', async () => {
-    isUserAuthorized.mockResolvedValue(true)
-
-    Task.mockImplementation(() => ({
-      save: vi.fn().mockRejectedValue(new Error('Fallo inesperado'))
-    }))
-
-    await addTask(ctx)
-
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '😵‍💫Ha sucedido un error al añadir tu tarea. Intentalo nuevamente'
-    )
-  })
 })

--- a/test/unit/controllers/taskController/taskSubControllers/clearTask.test.js
+++ b/test/unit/controllers/taskController/taskSubControllers/clearTask.test.js
@@ -63,8 +63,8 @@ describe('clearTask', () => {
     await clearTask(ctx)
 
     expect(ctx.reply).toHaveBeenCalledWith(
-      '🤯 Estás a punto de eliminar TODAS tus tareas.\n' +
-        'Si estás completamente seguro, escribe el comando:\n/confirmclear'
+      '❗ Estás a punto de eliminar *3* tareas. ¿Confirmas?',
+      expect.any(Object)
     )
   })
 
@@ -91,9 +91,7 @@ describe('clearTask', () => {
     await clearTask(ctx)
 
     expect(Task.deleteMany).toHaveBeenCalledWith({ userId })
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '🫡 Se han eliminado tus 2 tareas. ¡Empezamos de cero!'
-    )
+    expect(ctx.reply).toHaveBeenCalledWith('👌🏽 Tareas eliminadas')
   })
 
   // Parte 6: Cuando el comando no es válido entonces mostramos un mensaje de "Comando no válido"
@@ -117,7 +115,7 @@ describe('clearTask', () => {
     await clearTask(ctx)
 
     expect(ctx.reply).toHaveBeenCalledWith(
-      '😵‍💫 Ocurrió un error al procesar tu solicitud. Intenta más tarde.'
+      '😵‍💫 Ocurrió un error al iniciar el borrado. Intenta más tarde.'
     )
   })
 })

--- a/test/unit/controllers/taskController/taskSubControllers/completeTask.test.js
+++ b/test/unit/controllers/taskController/taskSubControllers/completeTask.test.js
@@ -39,23 +39,21 @@ describe('completeTask', () => {
     // Afirmo que la lógica se comportó como se esperaba.
     expect(mockTask.completed).toBe(true)
     expect(mockTask.save).toHaveBeenCalled()
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '🫡 Ojitooo finalizaste la tarea "Comprar pan", sigue así.'
-    )
+    expect(ctx.reply).toHaveBeenCalledWith('👌🏽 Tarea completada')
   })
 
   // Parte 2: Cuando la tarea no se encuentra se rechaza y entonces devolvemos un mensaje de error
   it('debe responder con un mensaje si ocurre un error en el helper', async () => {
     // Simulo que el helper no encuentra el valor de la tarea
     findUserTaskByName.mockResolvedValue({
-      error: '🤯 No se encoentro ninguna tarea llamada "Comprar pan"'
+      error: '🤯 No se encontró ninguna tarea llamada "Comprar pan"'
     })
 
     await completeTask(ctx)
 
     // Afirmo que la lógica se comportó como se esperaba.
     expect(ctx.reply).toHaveBeenCalledWith(
-      '🤯 No se encoentro ninguna tarea llamada "Comprar pan"'
+      '🤯 No se encontró ninguna tarea llamada "Comprar pan"'
     )
   })
 
@@ -67,7 +65,7 @@ describe('completeTask', () => {
 
     // Afirmo que la lógica se comportó como se esperaba.
     expect(ctx.reply).toHaveBeenCalledWith(
-      '😵‍💫 Ocurrio un error al completar la tarea. Intenta mas tarde.'
+      '😵‍💫 Algo salió mal al iniciar el flujo de completar tareas. Intenta más tarde.'
     )
   })
 })

--- a/test/unit/controllers/taskController/taskSubControllers/deleteTask.test.js
+++ b/test/unit/controllers/taskController/taskSubControllers/deleteTask.test.js
@@ -34,9 +34,7 @@ describe('deleteTask', () => {
     await deleteTask(ctx)
 
     expect(mockTask.deleteOne).toHaveBeenCalled()
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '🫡 Ojitooo eliminaste la tarea "Comprar pan". Ten cuidado y no la líes'
-    )
+    expect(ctx.reply).toHaveBeenCalledWith('👌🏽 Tarea eliminada')
   })
 
   // Parte 2: La tarea no se ha encontrado
@@ -59,7 +57,7 @@ describe('deleteTask', () => {
     await deleteTask(ctx)
 
     expect(ctx.reply).toHaveBeenCalledWith(
-      '😵‍💫 Ocurrio un error al eliminar la tarea. Intenta más tarde.'
+      '😵‍💫 Ocurrió un error al iniciar el flujo de eliminar tareas. Intenta más tarde.'
     )
   })
 })

--- a/test/unit/controllers/taskController/taskSubControllers/editTask.test.js
+++ b/test/unit/controllers/taskController/taskSubControllers/editTask.test.js
@@ -38,34 +38,10 @@ describe('editTask', () => {
     // Afirmo que la lógica se comportó como se esperaba.
     expect(mockTask.description).toBe('En la panadería nueva')
     expect(mockTask.save).toHaveBeenCalled()
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '🫡 Venga va, has actualizado la descripción de "Comprar pan". Ahora dice:\n"En la panadería nueva"'
-    )
+    expect(ctx.reply).toHaveBeenCalledWith('👌🏽 Tarea editada')
   })
 
-  // Parte 2: Debe de rechazar la edición si no hay un guión de separación
-  it('debe rechazar la edición si no hay un guión de separación', async () => {
-    ctx.message.text = '/edit Comprar pan'
-
-    await editTask(ctx)
-
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '🤯 Debes proporcionar una descripción de la tarea. Ejemplo:\n/edit Comprar pan - En la panadería nueva'
-    )
-  })
-
-  // Parte 3: Debe de rechazar la edición si no hay un nombre o una descripción de la tarea
-  it('debe rechazar la edición si no hay un nombre de tarea', async () => {
-    ctx.message.text = '/edit - Falta el nombre'
-
-    await editTask(ctx)
-
-    expect(ctx.reply).toHaveBeenCalledWith(
-      '🤯 Asegúrate de incluir tanto el nombre como la nueva descripción. Ejemplo:\n/edit Comprar pan - En la panadería nueva'
-    )
-  })
-
-  // Parte 4: Responde con un error si el helper no encuentra la tarea
+  // Parte 2: Responde con un error si el helper no encuentra la tarea
   it('debe responder con un error si el helper no encuentra la tarea', async () => {
     findUserTaskByName.mockResolvedValue({
       error: 'No se pudo encontrar la tarea'

--- a/test/unit/controllers/taskController/taskSubControllers/listTask.test.js
+++ b/test/unit/controllers/taskController/taskSubControllers/listTask.test.js
@@ -77,13 +77,11 @@ describe('listTasks', () => {
     // llamo la acción real de listTasks
     await listTasks(ctx)
 
-    // Creo el mensaje esperado
-    const expectedList =
-      '🗒️ Estas son tus tareas pendientes:\n\n' +
-      '🫡 1. Comprar pan\n' +
-      '🫡 2. Comprar ordenador'
-
-    expect(ctx.reply).toHaveBeenCalledWith(expectedList)
+    expect(ctx.reply).toHaveBeenCalledWith('Aquí tienes la lista')
+    expect(ctx.reply).toHaveBeenCalledWith(
+      'Selecciona una tarea para ver sus detalles:',
+      expect.any(Object)
+    )
   })
 
   // Parte 4: Muestro un error genérico si algo falla


### PR DESCRIPTION
## Summary
- adjust expectations for success messages across tests
- remove obsolete message references in unit tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444807affc83208497660201b7b4d4