### PR TITLE
Refactor flashReply to async delete

### DIFF
--- a/actions/addAction/confirmAction.js
+++ b/actions/addAction/confirmAction.js
@@ -34,6 +34,6 @@ export function registerConfirmAction(bot) {
     delete ctx.session.pendingTask
     delete ctx.session.menuMessageId
 
-    return flashReply(ctx, '👌🏽 Tarea creada')
+    flashReply(ctx, '👌🏽 Tarea creada')
   })
 }

--- a/actions/clearAction/clearActionHandler.js
+++ b/actions/clearAction/clearActionHandler.js
@@ -30,7 +30,7 @@ export function registerClearActions(bot) {
     ctx.session.pendingClearToken = null
 
     // 5) Mensaje final con delay
-    return flashReply(ctx, '👌🏽 Tareas eliminadas')
+    flashReply(ctx, '👌🏽 Tareas eliminadas')
   })
 
   // 2) Confirma “no”
@@ -39,6 +39,6 @@ export function registerClearActions(bot) {
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingClearToken = null
-    return flashReply(ctx, 'Operación cancelada.')
+    flashReply(ctx, 'Operación cancelada.')
   })
 }

--- a/actions/completeAction/completeActionHandler.js
+++ b/actions/completeAction/completeActionHandler.js
@@ -44,7 +44,7 @@ export function registerCompleteActions(bot) {
     ctx.session.flowType = null
     ctx.session.pendingComplete = null
 
-    return flashReply(ctx, '👌🏽 Tarea completada')
+    flashReply(ctx, '👌🏽 Tarea completada')
   })
 
   // 3 Confirma “No”
@@ -54,6 +54,6 @@ export function registerCompleteActions(bot) {
     ctx.session.flowType = null
     ctx.session.pendingComplete = null
 
-    return flashReply(ctx, 'Operación cancelada.')
+    flashReply(ctx, 'Operación cancelada.')
   })
 }

--- a/actions/deleteAction/deleteActionHandlers.js
+++ b/actions/deleteAction/deleteActionHandlers.js
@@ -39,7 +39,7 @@ export function registerDeleteActions(bot) {
     ctx.session.flowType = null
     ctx.session.pendingDelete = null
 
-    return flashReply(ctx, '👌🏽 Tarea eliminada')
+    flashReply(ctx, '👌🏽 Tarea eliminada')
   })
 
   // 3) Confirmación “No”
@@ -49,6 +49,6 @@ export function registerDeleteActions(bot) {
     ctx.session.flowType = null
     ctx.session.pendingDelete = null
 
-    return flashReply(ctx, 'Operación cancelada.')
+    flashReply(ctx, 'Operación cancelada.')
   })
 }

--- a/actions/editAction/saveEditAction.js
+++ b/actions/editAction/saveEditAction.js
@@ -19,9 +19,9 @@ export function registerSaveEditAction(bot) {
     )
     if (updated) {
       await task.save()
-      await flashReply(ctx, '👌🏽 Tarea editada')
+      flashReply(ctx, '👌🏽 Tarea editada')
     } else {
-      await flashReply(ctx, 'ℹ️ No hubo cambios.', { parse_mode: 'HTML' })
+      flashReply(ctx, 'ℹ️ No hubo cambios.', { parse_mode: 'HTML' })
     }
 
     // limpiamos todo

--- a/actions/timezoneAction/timezoneActionHandlers.js
+++ b/actions/timezoneAction/timezoneActionHandlers.js
@@ -48,11 +48,12 @@ export function registerTimezoneActions(bot) {
     ctx.session.pendingTz = null
 
     if (!updatedUser) {
-      return flashReply(ctx, '🥸 No estás autorizado para usar este bot.', {
+      flashReply(ctx, '🥸 No estás autorizado para usar este bot.', {
         parse_mode: 'HTML'
       })
+      return
     }
-    return flashReply(ctx, '🛫 zona cambiada')
+    flashReply(ctx, '🛫 zona cambiada')
   })
 
   // Paso 2b: confirma “No”
@@ -61,7 +62,7 @@ export function registerTimezoneActions(bot) {
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingTz = null
-    return flashReply(ctx, 'Cambio de zona horaria cancelado.', {
+    flashReply(ctx, 'Cambio de zona horaria cancelado.', {
       parse_mode: 'HTML'
     })
   })

--- a/controllers/taskControllers/listTask.js
+++ b/controllers/taskControllers/listTask.js
@@ -30,7 +30,7 @@ export const listTasks = async (ctx) => {
   ])
 
   // 4. Enviar mensaje con inline keyboard usando safeReply
-  await flashReply(ctx, 'Aquí tienes la lista')
+  flashReply(ctx, 'Aquí tienes la lista')
   return safeReply(ctx, 'Selecciona una tarea para ver sus detalles:', {
     reply_markup: { inline_keyboard: buttons }
   })

--- a/utils/delayUtils/flashReply.js
+++ b/utils/delayUtils/flashReply.js
@@ -1,4 +1,3 @@
-import { sleep } from './sleep.js'
 import { safeReply } from '../retryUtils/safeReply.js'
 
 /**
@@ -11,10 +10,12 @@ import { safeReply } from '../retryUtils/safeReply.js'
  */
 export const flashReply = async (ctx, text, opts = {}, ms = 1500) => {
   const msg = await safeReply(ctx, text, opts)
-  await sleep(ms)
-  try {
-    await ctx.telegram.deleteMessage(ctx.chat.id, msg.message_id)
-  } catch {
-    // ignore deletion errors
-  }
+  setTimeout(async () => {
+    try {
+      await ctx.telegram.deleteMessage(ctx.chat.id, msg.message_id)
+    } catch {
+      // ignore deletion errors
+    }
+  }, ms)
+  return msg
 }


### PR DESCRIPTION
## Summary
- delete flash messages asynchronously using `setTimeout`
- call `flashReply` without `await`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684447c4c25c8320a43f34436d0558e2