### PR TITLE
fix callback query messages

### DIFF
--- a/actions/addAction/confirmAction.js
+++ b/actions/addAction/confirmAction.js
@@ -11,7 +11,7 @@ import { getUserTimezone } from '../../helpers/taskHelpers/timezone/userTimezone
  */
 export function registerConfirmAction(bot) {
   bot.action('add_confirm', async (ctx) => {
-    await safeAnswerCbQuery(ctx)
+    await safeAnswerCbQuery(ctx, '👌🏽 Tarea creada')
     await safeEditMessageReplyMarkup(ctx)
 
     const { pendingTask } = ctx.session

--- a/actions/clearAction/clearActionHandler.js
+++ b/actions/clearAction/clearActionHandler.js
@@ -22,7 +22,7 @@ export function registerClearActions(bot) {
     const result = await Task.deleteMany({ userId })
 
     // 3) Quito spinner y botones
-    await safeAnswerCbQuery(ctx)
+    await safeAnswerCbQuery(ctx, '👌🏽 Tareas eliminadas')
     await safeEditMessageReplyMarkup(ctx)
 
     // 4) Limpio sesión
@@ -35,7 +35,7 @@ export function registerClearActions(bot) {
 
   // 2) Confirma “no”
   bot.action(/^clear_confirm_(.+):no$/, async (ctx) => {
-    await safeAnswerCbQuery(ctx)
+    await safeAnswerCbQuery(ctx, 'Operación cancelada.')
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingClearToken = null

--- a/actions/completeAction/completeActionHandler.js
+++ b/actions/completeAction/completeActionHandler.js
@@ -39,7 +39,7 @@ export function registerCompleteActions(bot) {
     const taskId = ctx.session.pendingComplete
     await Task.findByIdAndUpdate(taskId, { completed: true })
 
-    await safeAnswerCbQuery(ctx)
+    await safeAnswerCbQuery(ctx, '👌🏽 Tarea completada')
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingComplete = null
@@ -49,7 +49,7 @@ export function registerCompleteActions(bot) {
 
   // 3 Confirma “No”
   bot.action('complete_confirm:no', async (ctx) => {
-    await safeAnswerCbQuery(ctx)
+    await safeAnswerCbQuery(ctx, 'Operación cancelada.')
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingComplete = null

--- a/actions/deleteAction/deleteActionHandlers.js
+++ b/actions/deleteAction/deleteActionHandlers.js
@@ -33,7 +33,7 @@ export function registerDeleteActions(bot) {
     const taskId = ctx.session.pendingDelete
     await Task.findByIdAndDelete(taskId)
 
-    await safeAnswerCbQuery(ctx)
+    await safeAnswerCbQuery(ctx, '👌🏽 Tarea eliminada')
     await safeEditMessageReplyMarkup(ctx)
     // Limpiamos el flujo
     ctx.session.flowType = null
@@ -44,7 +44,7 @@ export function registerDeleteActions(bot) {
 
   // 3) Confirmación “No”
   bot.action('delete_confirm:no', async (ctx) => {
-    await safeAnswerCbQuery(ctx)
+    await safeAnswerCbQuery(ctx, 'Operación cancelada.')
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingDelete = null

--- a/actions/editAction/saveEditAction.js
+++ b/actions/editAction/saveEditAction.js
@@ -6,7 +6,6 @@ import { Task } from '../../models/task.js'
 
 export function registerSaveEditAction(bot) {
   bot.action('edit_save', async (ctx) => {
-    await safeAnswerCbQuery(ctx)
     await safeEditMessageReplyMarkup(ctx)
 
     const { editing, edits } = ctx.session
@@ -17,12 +16,16 @@ export function registerSaveEditAction(bot) {
       edits,
       ctx.session.timezone
     )
+    let cbText
     if (updated) {
       await task.save()
-      flashReply(ctx, '👌🏽 Tarea editada')
+      cbText = '👌🏽 Tarea editada'
+      flashReply(ctx, cbText)
     } else {
-      flashReply(ctx, 'ℹ️ No hubo cambios.', { parse_mode: 'HTML' })
+      cbText = 'ℹ️ No hubo cambios.'
+      flashReply(ctx, cbText, { parse_mode: 'HTML' })
     }
+    await safeAnswerCbQuery(ctx, cbText)
 
     // limpiamos todo
     delete ctx.session.flowType

--- a/actions/timezoneAction/timezoneActionHandlers.js
+++ b/actions/timezoneAction/timezoneActionHandlers.js
@@ -31,7 +31,6 @@ export function registerTimezoneActions(bot) {
 
   // Paso 2a: confirma “Sí”
   bot.action('confirm_tz_yes', async (ctx) => {
-    await safeAnswerCbQuery(ctx)
     await safeEditMessageReplyMarkup(ctx)
     const tz = ctx.session.pendingTz
     const userId = ctx.from.id
@@ -49,20 +48,23 @@ export function registerTimezoneActions(bot) {
     ctx.session.pendingTz = null
 
     if (!updatedUser) {
-      flashReply(ctx, '🥸 No estás autorizado para usar este bot.', {
+      const msg = '🥸 No estás autorizado para usar este bot.'
+      await safeAnswerCbQuery(ctx, msg)
+      flashReply(ctx, msg, {
         parse_mode: 'HTML'
       })
       return
     }
+    await safeAnswerCbQuery(ctx, '🛫 zona cambiada')
     flashReply(ctx, '🛫 zona cambiada')
   })
 
   // Paso 2b: confirma “No”
   bot.action('confirm_tz_no', async (ctx) => {
-    await safeAnswerCbQuery(ctx)
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingTz = null
+    await safeAnswerCbQuery(ctx, 'Cambio de zona horaria cancelado.')
     flashReply(ctx, 'Cambio de zona horaria cancelado.', {
       parse_mode: 'HTML'
     })

--- a/utils/retryUtils/safeAnswerCbQuery.js
+++ b/utils/retryUtils/safeAnswerCbQuery.js
@@ -2,7 +2,7 @@ import { sleep } from '../delayUtils/sleep.js'
 
 export async function safeAnswerCbQuery(
   ctx,
-  textOrOpts = {},
+  textOrOpts = undefined,
   opts = {},
   retries = 3
 ) {
@@ -10,11 +10,13 @@ export async function safeAnswerCbQuery(
   while (true) {
     try {
       // permite dos firmas: answerCbQuery(text, opts) o answerCbQuery(opts)
+      if (textOrOpts === undefined) {
+        return await ctx.answerCbQuery()
+      }
       if (typeof textOrOpts === 'string') {
         return await ctx.answerCbQuery(textOrOpts, opts)
-      } else {
-        return await ctx.answerCbQuery(textOrOpts)
       }
+      return await ctx.answerCbQuery(textOrOpts)
     } catch (err) {
       if (++attempt > retries || err.code !== 'ECONNRESET') {
         throw err


### PR DESCRIPTION
## Summary
- avoid `{}` default by skipping empty callbacks in `safeAnswerCbQuery`
- show success text in confirmation popups for add, edit, delete, clear, complete, and timezone actions

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444fb4b7508320984f39c843d18337