### PR TITLE
fix: delete edit_save message

### DIFF
--- a/actions/editAction/saveEditAction.js
+++ b/actions/editAction/saveEditAction.js
@@ -27,6 +27,11 @@ export function registerSaveEditAction(bot) {
     }
     await safeAnswerCbQuery(ctx, cbText)
 
+    // Elimino el mensaje original solo si existe
+    if (ctx.callbackQuery?.message) {
+      await ctx.deleteMessage().catch(() => {})
+    }
+
     // limpiamos todo
     delete ctx.session.flowType
     delete ctx.session.editing


### PR DESCRIPTION
## Summary
- remove edit menu after saving task to avoid leftover message

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445c92288c832097b4ce66e6e5ecaa