### PR TITLE
Fix confirm action to remove menu message

### DIFF
--- a/actions/addAction/confirmAction.js
+++ b/actions/addAction/confirmAction.js
@@ -14,6 +14,10 @@ export function registerConfirmAction(bot) {
     await safeAnswerCbQuery(ctx, '👌🏽 Tarea creada')
     await safeEditMessageReplyMarkup(ctx)
 
+    if (ctx.callbackQuery?.message) {
+      await ctx.deleteMessage().catch(() => {})
+    }
+
     const { pendingTask } = ctx.session
     const userId = ctx.from.id
 


### PR DESCRIPTION
## Summary
- remove the inline menu message after confirming an action

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684460b3ee2083208489ade66575f5a9