### PR TITLE
Remove flash messages from action handlers

### DIFF
--- a/actions/clearAction/clearActionHandler.js
+++ b/actions/clearAction/clearActionHandler.js
@@ -29,8 +29,6 @@ export function registerClearActions(bot) {
     ctx.session.flowType = null
     ctx.session.pendingClearToken = null
 
-    // 5) Mensaje final con delay
-    flashReply(ctx, '👌🏽 Tareas eliminadas')
   })
 
   // 2) Confirma “no”
@@ -39,6 +37,5 @@ export function registerClearActions(bot) {
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingClearToken = null
-    flashReply(ctx, 'Operación cancelada.')
   })
 }

--- a/actions/completeAction/completeActionHandler.js
+++ b/actions/completeAction/completeActionHandler.js
@@ -43,8 +43,6 @@ export function registerCompleteActions(bot) {
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingComplete = null
-
-    flashReply(ctx, '👌🏽 Tarea completada')
   })
 
   // 3 Confirma “No”
@@ -53,7 +51,5 @@ export function registerCompleteActions(bot) {
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingComplete = null
-
-    flashReply(ctx, 'Operación cancelada.')
   })
 }

--- a/actions/deleteAction/deleteActionHandlers.js
+++ b/actions/deleteAction/deleteActionHandlers.js
@@ -38,8 +38,6 @@ export function registerDeleteActions(bot) {
     // Limpiamos el flujo
     ctx.session.flowType = null
     ctx.session.pendingDelete = null
-
-    flashReply(ctx, '👌🏽 Tarea eliminada')
   })
 
   // 3) Confirmación “No”
@@ -48,7 +46,5 @@ export function registerDeleteActions(bot) {
     await safeEditMessageReplyMarkup(ctx)
     ctx.session.flowType = null
     ctx.session.pendingDelete = null
-
-    flashReply(ctx, 'Operación cancelada.')
   })
 }

--- a/actions/listAction/listActionHandlers.js
+++ b/actions/listAction/listActionHandlers.js
@@ -33,8 +33,6 @@ export function registerListActions(bot) {
     // 4) Responder al callback con un toast
     await safeAnswerCbQuery(ctx, 'Aquí tienes los detalles de la tarea')
 
-    // 5) Mensaje temporal en el chat
-    flashReply(ctx, 'Aquí tienes los detalles de la tarea')
 
     // 6) Enviar los detalles completos
     return safeReply(ctx, `${nameLine}${descLine}${dateLine}`, {

--- a/actions/timezoneAction/timezoneActionHandlers.js
+++ b/actions/timezoneAction/timezoneActionHandlers.js
@@ -50,13 +50,9 @@ export function registerTimezoneActions(bot) {
     if (!updatedUser) {
       const msg = '🥸 No estás autorizado para usar este bot.'
       await safeAnswerCbQuery(ctx, msg)
-      flashReply(ctx, msg, {
-        parse_mode: 'HTML'
-      })
       return
     }
     await safeAnswerCbQuery(ctx, '🛫 zona cambiada')
-    flashReply(ctx, '🛫 zona cambiada')
   })
 
   // Paso 2b: confirma “No”
@@ -65,8 +61,5 @@ export function registerTimezoneActions(bot) {
     ctx.session.flowType = null
     ctx.session.pendingTz = null
     await safeAnswerCbQuery(ctx, 'Cambio de zona horaria cancelado.')
-    flashReply(ctx, 'Cambio de zona horaria cancelado.', {
-      parse_mode: 'HTML'
-    })
   })
 }


### PR DESCRIPTION
## Summary
- remove `flashReply` calls after `safeAnswerCbQuery`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847134a466c83208456ebc8679ad3c6