### PR TITLE
Add flash reply after timezone change

### DIFF
--- a/actions/timezoneAction/timezoneActionHandlers.js
+++ b/actions/timezoneAction/timezoneActionHandlers.js
@@ -53,6 +53,7 @@ export function registerTimezoneActions(bot) {
       return
     }
     await safeAnswerCbQuery(ctx, '🛫 zona cambiada')
+    flashReply(ctx, 'Zona cambiada')
   })
 
   // Paso 2b: confirma “No”


### PR DESCRIPTION
## Summary
- flash a brief confirmation message when changing timezone

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471dc76228832080b1bb2935183950