### PR TITLE
Add flashReply after clearing tasks

### DIFF
--- a/actions/clearAction/clearActionHandler.js
+++ b/actions/clearAction/clearActionHandler.js
@@ -1,6 +1,7 @@
 import { Task } from '../../models/task.js'
 import { safeAnswerCbQuery } from '../../utils/retryUtils/safeAnswerCbQuery.js'
 import { safeEditMessageReplyMarkup } from '../../utils/retryUtils/safeEditMessageReplyMarkup.js'
+import { flashReply } from '../../utils/delayUtils/flashReply.js'
 
 /**
  * Registra los callbacks para completar o cancelar /clear
@@ -27,6 +28,8 @@ export function registerClearActions(bot) {
     // 4) Limpio sesión
     ctx.session.flowType = null
     ctx.session.pendingClearToken = null
+
+    flashReply(ctx, 'Lista restablecida')
 
   })
 


### PR DESCRIPTION
## Summary
- send a flash confirmation after clearing tasks
- expose flashReply in clearAction handler

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68471dc544a88320a2fbf163bb12d626