### PR TITLE
Fix deletion toast

### DIFF
--- a/actions/deleteAction/deleteActionHandlers.js
+++ b/actions/deleteAction/deleteActionHandlers.js
@@ -34,6 +34,7 @@ export function registerDeleteActions(bot) {
     await Task.findByIdAndDelete(taskId)
 
     await safeAnswerCbQuery(ctx, '👌🏽 Tarea eliminada')
+    await flashReply(ctx, 'Tarea eliminada')
     await safeEditMessageReplyMarkup(ctx)
     // Limpiamos el flujo
     ctx.session.flowType = null


### PR DESCRIPTION
## Summary
- show a flash reply when deleting a task so user sees confirmation toast

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471dc331ac8320ba0efa78e9d44ebe