### PR TITLE
Register reminder actions

### DIFF
--- a/actions/reminderAction/index.js
+++ b/actions/reminderAction/index.js
@@ -1,0 +1,10 @@
+import { isAuthorizedUser } from '../../middlewares/access/isAuthorizedUser.js'
+import { startReminderAction } from './startReminderAction.js'
+import { saveReminderAction } from './saveReminderAction.js'
+import { handleReminderFrequency } from '../../events/reminderEvent/handleReminderFrequency.js'
+
+export function registerReminderActions(bot) {
+  bot.command('reminder', isAuthorizedUser, startReminderAction)
+  bot.action(/^setReminder::/, handleReminderFrequency)
+  bot.action(/^saveReminder::/, saveReminderAction)
+}

--- a/actions/reminderAction/startReminderAction.js
+++ b/actions/reminderAction/startReminderAction.js
@@ -1,11 +1,11 @@
 // 📁 actions/reminderAction/startReminderAction.js
 
-import { getActiveTasksByUser } from '../../helpers/taskHelpers/edit/taskSelection.js'
+import { findAllTasks } from '../../helpers/tasks/findAllTasks.js'
 import { safeReply } from '../../utils/retryUtils/safeReply.js'
 
 export const startReminderAction = async (ctx) => {
   const userId = ctx.from.id
-  const tasks = await getActiveTasksByUser(userId)
+  const tasks = await findAllTasks(userId)
 
   if (!tasks.length) {
     return safeReply(

--- a/config/telegraf/telegraf.js
+++ b/config/telegraf/telegraf.js
@@ -21,6 +21,7 @@ import { registerCompleteActions } from '../../actions/completeAction/completeAc
 import { registerDeleteActions } from '../../actions/deleteAction/deleteActionHandlers.js'
 import { registerClearActions } from '../../actions/clearAction/clearActionHandler.js'
 import { registerAddAction } from '../../actions/addAction/index.js'
+import { registerReminderActions } from '../../actions/reminderAction/index.js'
 import { debugLog } from '../../utils/logUtils/debugLog.js'
 
 // Me aseguro que el token exista
@@ -82,6 +83,7 @@ registerDeleteActions(bot)
 registerClearActions(bot)
 registerTimezoneActions(bot)
 registerListActions(bot)
+registerReminderActions(bot)
 
 bot.on('message', async (ctx, next) => {
   debugLog('🧪 [TRACE] bot.on(message) interceptó:', ctx.message?.text)


### PR DESCRIPTION
## Summary
- hook up startReminderAction to findAllTasks
- export registerReminderActions to configure reminder handlers
- register reminder flows with Telegraf bot

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473b8bc3ac83209164d3261644348c