### PR TITLE
Add reminder frequency menu via helper and unit tests

### DIFF
--- a/events/reminderEvent/handleReminderFrequency.js
+++ b/events/reminderEvent/handleReminderFrequency.js
@@ -1,5 +1,6 @@
 import { Task } from '../../models/task.js'
 import { safeEditMessageReplyMarkup } from '../../utils/retryUtils/safeEditMessageReplyMarkup.js'
+import { buildFrequencyMenu } from '../../helpers/frequency/flowFrequency/interactiveFlowFrequency.js'
 
 export const handleReminderFrequency = async (ctx) => {
   const callbackData = ctx.callbackQuery.data
@@ -10,12 +11,17 @@ export const handleReminderFrequency = async (ctx) => {
     return ctx.answerCbQuery('Tarea no encontrada.')
   }
 
-  const frequencyOptions = [
-    [{ text: 'Diario', callback_data: `saveReminder::${taskId}::daily` }],
-    [{ text: 'Semanal', callback_data: `saveReminder::${taskId}::weekly` }],
-    [{ text: 'Mensual', callback_data: `saveReminder::${taskId}::monthly` }],
-    [{ text: 'Anual', callback_data: `saveReminder::${taskId}::yearly` }]
-  ]
+  const { markup } = buildFrequencyMenu()
+  const frequencyOptions = markup.reply_markup.inline_keyboard.map((row) => {
+    const button = row[0]
+    const value = button.callback_data.replace('add_freq_', '')
+    return [
+      {
+        text: button.text,
+        callback_data: `saveReminder::${taskId}::${value}`
+      }
+    ]
+  })
 
   await ctx.answerCbQuery()
 

--- a/test/unit/actions/reminderAction/handleReminderFrequency.test.js
+++ b/test/unit/actions/reminderAction/handleReminderFrequency.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { handleReminderFrequency } from '@/events/reminderEvent/handleReminderFrequency.js'
+import { Task } from '@/models/task.js'
+import { buildFrequencyMenu } from '@/helpers/frequency/flowFrequency/interactiveFlowFrequency.js'
+import { safeEditMessageReplyMarkup } from '@/utils/retryUtils/safeEditMessageReplyMarkup.js'
+
+vi.mock('@/models/task.js', () => ({
+  Task: { findById: vi.fn() }
+}))
+
+vi.mock('@/helpers/frequency/flowFrequency/interactiveFlowFrequency.js', () => ({
+  buildFrequencyMenu: vi.fn()
+}))
+
+vi.mock('@/utils/retryUtils/safeEditMessageReplyMarkup.js', () => ({
+  safeEditMessageReplyMarkup: vi.fn()
+}))
+
+describe('handleReminderFrequency', () => {
+  const ctx = { callbackQuery: { data: 'setReminder::42' }, answerCbQuery: vi.fn() }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the keyboard returned by buildFrequencyMenu', async () => {
+    Task.findById.mockResolvedValue({ _id: '42', name: 'Task' })
+    buildFrequencyMenu.mockReturnValue({
+      text: 'texto',
+      markup: {
+        reply_markup: {
+          inline_keyboard: [
+            [{ text: 'Diario', callback_data: 'add_freq_daily' }],
+            [{ text: 'Semanal', callback_data: 'add_freq_weekly' }]
+          ]
+        }
+      }
+    })
+
+    await handleReminderFrequency(ctx)
+
+    expect(buildFrequencyMenu).toHaveBeenCalled()
+    expect(ctx.answerCbQuery).toHaveBeenCalled()
+    expect(safeEditMessageReplyMarkup).toHaveBeenCalledWith(ctx, {
+      reply_markup: {
+        inline_keyboard: [
+          [{ text: 'Diario', callback_data: 'saveReminder::42::daily' }],
+          [{ text: 'Semanal', callback_data: 'saveReminder::42::weekly' }]
+        ]
+      }
+    })
+  })
+})

--- a/test/unit/actions/reminderAction/saveReminderAction.test.js
+++ b/test/unit/actions/reminderAction/saveReminderAction.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { saveReminderAction } from '@/actions/reminderAction/saveReminderAction.js'
+import { Task } from '@/models/task.js'
+import { flashReply } from '@/utils/delayUtils/flashReply.js'
+
+vi.mock('@/models/task.js', () => ({
+  Task: { findById: vi.fn() }
+}))
+
+vi.mock('@/utils/delayUtils/flashReply.js', () => ({
+  flashReply: vi.fn()
+}))
+
+describe('saveReminderAction', () => {
+  const ctx = { callbackQuery: { data: 'saveReminder::100::weekly' }, answerCbQuery: vi.fn() }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'))
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('updates frequency and reminderAt on the chosen task', async () => {
+    const saveMock = vi.fn()
+    const task = {
+      _id: '100',
+      name: 'My task',
+      frequency: 'daily',
+      reminderAt: new Date('2023-12-31T00:00:00Z'),
+      alertsSent: ['72h'],
+      save: saveMock
+    }
+    Task.findById.mockResolvedValue(task)
+
+    await saveReminderAction(ctx)
+
+    expect(task.frequency).toBe('weekly')
+    expect(task.reminderAt.getTime() - new Date('2024-01-01T00:00:00Z').getTime()).toBe(
+      7 * 24 * 60 * 60 * 1000
+    )
+    expect(task.alertsSent).toEqual([])
+    expect(saveMock).toHaveBeenCalled()
+    expect(ctx.answerCbQuery).toHaveBeenCalled()
+    expect(flashReply).toHaveBeenCalledWith(
+      ctx,
+      expect.stringContaining('My task'),
+      {},
+      2500
+    )
+  })
+})

--- a/test/unit/actions/reminderAction/startReminderAction.test.js
+++ b/test/unit/actions/reminderAction/startReminderAction.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { startReminderAction } from '@/actions/reminderAction/startReminderAction.js'
+import { getActiveTasksByUser } from '@/helpers/taskHelpers/edit/taskSelection.js'
+
+vi.mock('@/helpers/taskHelpers/edit/taskSelection.js', () => ({
+  getActiveTasksByUser: vi.fn()
+}))
+
+describe('startReminderAction', () => {
+  const ctx = { from: { id: 1 }, reply: vi.fn() }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('lists tasks with current frequency labels', async () => {
+    const now = new Date()
+    getActiveTasksByUser.mockResolvedValue([
+      { _id: '1', name: 'Task 1', reminderAt: now, frequency: 'daily' },
+      { _id: '2', name: 'Task 2', reminderAt: null, frequency: 'weekly' }
+    ])
+
+    await startReminderAction(ctx)
+
+    expect(getActiveTasksByUser).toHaveBeenCalledWith(1)
+    expect(ctx.reply).toHaveBeenCalledWith(
+      'Selecciona una tarea para configurar su recordatorio:',
+      {
+        reply_markup: {
+          inline_keyboard: [
+            [{ text: 'Task 1 \u2014 Diario', callback_data: 'setReminder::1' }],
+            [{ text: 'Task 2 \u2014 Sin recordatorio', callback_data: 'setReminder::2' }]
+          ]
+        }
+      }
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- reuse `buildFrequencyMenu` when editing reminder frequency
- cover reminder actions with unit tests

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68473bc2a8f88320b168253cf86a2076