### PR TITLE
Use safeReply for startReminderAction

### DIFF
--- a/actions/reminderAction/startReminderAction.js
+++ b/actions/reminderAction/startReminderAction.js
@@ -34,7 +34,7 @@ export const startReminderAction = async (ctx) => {
     ]
   })
 
-  return ctx.reply('Selecciona una tarea para configurar su recordatorio:', {
+  return safeReply(ctx, 'Selecciona una tarea para configurar su recordatorio:', {
     reply_markup: {
       inline_keyboard: buttons
     }

--- a/test/unit/actions/reminderAction/startReminderAction.test.js
+++ b/test/unit/actions/reminderAction/startReminderAction.test.js
@@ -1,9 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { startReminderAction } from '@/actions/reminderAction/startReminderAction.js'
 import { getActiveTasksByUser } from '@/helpers/taskHelpers/edit/taskSelection.js'
+import { safeReply } from '@/utils/retryUtils/safeReply.js'
 
 vi.mock('@/helpers/taskHelpers/edit/taskSelection.js', () => ({
   getActiveTasksByUser: vi.fn()
+}))
+
+vi.mock('@/utils/retryUtils/safeReply.js', () => ({
+  safeReply: vi.fn()
 }))
 
 describe('startReminderAction', () => {
@@ -23,16 +28,13 @@ describe('startReminderAction', () => {
     await startReminderAction(ctx)
 
     expect(getActiveTasksByUser).toHaveBeenCalledWith(1)
-    expect(ctx.reply).toHaveBeenCalledWith(
-      'Selecciona una tarea para configurar su recordatorio:',
-      {
-        reply_markup: {
-          inline_keyboard: [
-            [{ text: 'Task 1 \u2014 Diario', callback_data: 'setReminder::1' }],
-            [{ text: 'Task 2 \u2014 Sin recordatorio', callback_data: 'setReminder::2' }]
-          ]
-        }
+    expect(safeReply).toHaveBeenCalledWith(ctx, 'Selecciona una tarea para configurar su recordatorio:', {
+      reply_markup: {
+        inline_keyboard: [
+          [{ text: 'Task 1 \u2014 Diario', callback_data: 'setReminder::1' }],
+          [{ text: 'Task 2 \u2014 Sin recordatorio', callback_data: 'setReminder::2' }]
+        ]
       }
-    )
+    })
   })
 })


### PR DESCRIPTION
## Summary
- switch `ctx.reply` to `safeReply` in the reminder action
- update tests to expect `safeReply`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847476945848320b6526a9bc3aa3e22