### PR TITLE
Use safeAnswerCbQuery

### DIFF
--- a/actions/reminderAction/saveReminderAction.js
+++ b/actions/reminderAction/saveReminderAction.js
@@ -1,5 +1,6 @@
 import { Task } from '../../models/task.js'
 import { flashReply } from '../../utils/delayUtils/flashReply.js'
+import { safeAnswerCbQuery } from '../../utils/retryUtils/safeAnswerCbQuery.js'
 
 const addIntervalToNow = (frequency) => {
   const now = new Date()
@@ -26,7 +27,7 @@ export const saveReminderAction = async (ctx) => {
 
   const task = await Task.findById(taskId)
   if (!task) {
-    return ctx.answerCbQuery('Tarea no encontrada.')
+    return safeAnswerCbQuery(ctx, 'Tarea no encontrada.')
   }
 
   task.frequency = frequency
@@ -34,7 +35,7 @@ export const saveReminderAction = async (ctx) => {
   task.alertsSent = [] // Resetea las alertas pasadas
 
   await task.save()
-  await ctx.answerCbQuery()
+  await safeAnswerCbQuery(ctx)
 
   return flashReply(
     ctx,

--- a/events/reminderEvent/handleReminderFrequency.js
+++ b/events/reminderEvent/handleReminderFrequency.js
@@ -1,5 +1,6 @@
 import { Task } from '../../models/task.js'
 import { safeEditMessageReplyMarkup } from '../../utils/retryUtils/safeEditMessageReplyMarkup.js'
+import { safeAnswerCbQuery } from '../../utils/retryUtils/safeAnswerCbQuery.js'
 import { buildFrequencyMenu } from '../../helpers/frequency/flowFrequency/interactiveFlowFrequency.js'
 
 export const handleReminderFrequency = async (ctx) => {
@@ -8,7 +9,7 @@ export const handleReminderFrequency = async (ctx) => {
 
   const task = await Task.findById(taskId)
   if (!task) {
-    return ctx.answerCbQuery('Tarea no encontrada.')
+    return safeAnswerCbQuery(ctx, 'Tarea no encontrada.')
   }
 
   const { markup } = buildFrequencyMenu()
@@ -23,7 +24,7 @@ export const handleReminderFrequency = async (ctx) => {
     ]
   })
 
-  await ctx.answerCbQuery()
+  await safeAnswerCbQuery(ctx)
 
   return safeEditMessageReplyMarkup(ctx, {
     reply_markup: {

--- a/test/unit/actions/reminderAction/handleReminderFrequency.test.js
+++ b/test/unit/actions/reminderAction/handleReminderFrequency.test.js
@@ -3,6 +3,7 @@ import { handleReminderFrequency } from '@/events/reminderEvent/handleReminderFr
 import { Task } from '@/models/task.js'
 import { buildFrequencyMenu } from '@/helpers/frequency/flowFrequency/interactiveFlowFrequency.js'
 import { safeEditMessageReplyMarkup } from '@/utils/retryUtils/safeEditMessageReplyMarkup.js'
+import { safeAnswerCbQuery } from '@/utils/retryUtils/safeAnswerCbQuery.js'
 
 vi.mock('@/models/task.js', () => ({
   Task: { findById: vi.fn() }
@@ -14,6 +15,10 @@ vi.mock('@/helpers/frequency/flowFrequency/interactiveFlowFrequency.js', () => (
 
 vi.mock('@/utils/retryUtils/safeEditMessageReplyMarkup.js', () => ({
   safeEditMessageReplyMarkup: vi.fn()
+}))
+
+vi.mock('@/utils/retryUtils/safeAnswerCbQuery.js', () => ({
+  safeAnswerCbQuery: vi.fn()
 }))
 
 describe('handleReminderFrequency', () => {
@@ -40,7 +45,7 @@ describe('handleReminderFrequency', () => {
     await handleReminderFrequency(ctx)
 
     expect(buildFrequencyMenu).toHaveBeenCalled()
-    expect(ctx.answerCbQuery).toHaveBeenCalled()
+    expect(safeAnswerCbQuery).toHaveBeenCalledWith(ctx)
     expect(safeEditMessageReplyMarkup).toHaveBeenCalledWith(ctx, {
       reply_markup: {
         inline_keyboard: [

--- a/test/unit/actions/reminderAction/saveReminderAction.test.js
+++ b/test/unit/actions/reminderAction/saveReminderAction.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { saveReminderAction } from '@/actions/reminderAction/saveReminderAction.js'
 import { Task } from '@/models/task.js'
 import { flashReply } from '@/utils/delayUtils/flashReply.js'
+import { safeAnswerCbQuery } from '@/utils/retryUtils/safeAnswerCbQuery.js'
 
 vi.mock('@/models/task.js', () => ({
   Task: { findById: vi.fn() }
@@ -9,6 +10,10 @@ vi.mock('@/models/task.js', () => ({
 
 vi.mock('@/utils/delayUtils/flashReply.js', () => ({
   flashReply: vi.fn()
+}))
+
+vi.mock('@/utils/retryUtils/safeAnswerCbQuery.js', () => ({
+  safeAnswerCbQuery: vi.fn()
 }))
 
 describe('saveReminderAction', () => {
@@ -44,7 +49,7 @@ describe('saveReminderAction', () => {
     )
     expect(task.alertsSent).toEqual([])
     expect(saveMock).toHaveBeenCalled()
-    expect(ctx.answerCbQuery).toHaveBeenCalled()
+    expect(safeAnswerCbQuery).toHaveBeenCalledWith(ctx)
     expect(flashReply).toHaveBeenCalledWith(
       ctx,
       expect.stringContaining('My task'),


### PR DESCRIPTION
## Summary
- use `safeAnswerCbQuery` utility in reminder handlers
- adjust unit tests to mock `safeAnswerCbQuery`

## Testing
- `npm test` *(fails: vitest missing)*

------
https://chatgpt.com/codex/tasks/task_e_684747703148832091e1576dd61f5fcf