### PR TITLE
Handle reminder frequency editing

### DIFF
--- a/events/reminderEvent/handleReminderFrequency.js
+++ b/events/reminderEvent/handleReminderFrequency.js
@@ -11,7 +11,7 @@ export const handleReminderFrequency = async (ctx) => {
     return ctx.answerCbQuery('Tarea no encontrada.')
   }
 
-  const { markup } = buildFrequencyMenu()
+  const { text, markup } = buildFrequencyMenu()
   const frequencyOptions = markup.reply_markup.inline_keyboard.map((row) => {
     const button = row[0]
     const value = button.callback_data.replace('add_freq_', '')
@@ -25,9 +25,23 @@ export const handleReminderFrequency = async (ctx) => {
 
   await ctx.answerCbQuery()
 
-  return safeEditMessageReplyMarkup(ctx, {
-    reply_markup: {
-      inline_keyboard: frequencyOptions
-    }
-  })
+  try {
+    return await ctx.telegram.editMessageText(
+      ctx.chat.id,
+      ctx.callbackQuery.message.message_id,
+      undefined,
+      text,
+      {
+        reply_markup: {
+          inline_keyboard: frequencyOptions
+        }
+      }
+    )
+  } catch {
+    return safeEditMessageReplyMarkup(ctx, {
+      reply_markup: {
+        inline_keyboard: frequencyOptions
+      }
+    })
+  }
 }

--- a/test/unit/actions/reminderAction/handleReminderFrequency.test.js
+++ b/test/unit/actions/reminderAction/handleReminderFrequency.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { handleReminderFrequency } from '@/events/reminderEvent/handleReminderFrequency.js'
 import { Task } from '@/models/task.js'
 import { buildFrequencyMenu } from '@/helpers/frequency/flowFrequency/interactiveFlowFrequency.js'
@@ -17,7 +17,15 @@ vi.mock('@/utils/retryUtils/safeEditMessageReplyMarkup.js', () => ({
 }))
 
 describe('handleReminderFrequency', () => {
-  const ctx = { callbackQuery: { data: 'setReminder::42' }, answerCbQuery: vi.fn() }
+  const ctx = {
+    callbackQuery: {
+      data: 'setReminder::42',
+      message: { message_id: 10 }
+    },
+    chat: { id: 5 },
+    telegram: { editMessageText: vi.fn(() => Promise.reject(new Error('fail'))) },
+    answerCbQuery: vi.fn()
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -39,15 +47,24 @@ describe('handleReminderFrequency', () => {
 
     await handleReminderFrequency(ctx)
 
-    expect(buildFrequencyMenu).toHaveBeenCalled()
-    expect(ctx.answerCbQuery).toHaveBeenCalled()
-    expect(safeEditMessageReplyMarkup).toHaveBeenCalledWith(ctx, {
+    const expectedMarkup = {
       reply_markup: {
         inline_keyboard: [
           [{ text: 'Diario', callback_data: 'saveReminder::42::daily' }],
           [{ text: 'Semanal', callback_data: 'saveReminder::42::weekly' }]
         ]
       }
-    })
+    }
+
+    expect(buildFrequencyMenu).toHaveBeenCalled()
+    expect(ctx.answerCbQuery).toHaveBeenCalled()
+    expect(ctx.telegram.editMessageText).toHaveBeenCalledWith(
+      5,
+      10,
+      undefined,
+      'texto',
+      expectedMarkup
+    )
+    expect(safeEditMessageReplyMarkup).toHaveBeenCalledWith(ctx, expectedMarkup)
   })
 })


### PR DESCRIPTION
## Summary
- edit menu text for reminder frequency updates
- verify editMessageText is invoked in unit tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847477568348320a65527232e3532c0