### PR TITLE
Refactor reminder frequency labels

### DIFF
--- a/actions/reminderAction/startReminderAction.js
+++ b/actions/reminderAction/startReminderAction.js
@@ -2,6 +2,7 @@
 
 import { findAllTasks } from '../../helpers/tasks/findAllTasks.js'
 import { safeReply } from '../../utils/retryUtils/safeReply.js'
+import { frequencyLabels } from '../../helpers/frequency/frequencyLabels.js'
 
 export const startReminderAction = async (ctx) => {
   const userId = ctx.from.id
@@ -15,15 +16,8 @@ export const startReminderAction = async (ctx) => {
   }
 
   const buttons = tasks.map((task) => {
-    const freqMap = {
-      daily: 'Diario',
-      weekly: 'Semanal',
-      monthly: 'Mensual',
-      yearly: 'Anual'
-    }
-
     const label = `${task.name} — ${
-      task.reminderAt ? freqMap[task.frequency] : 'Sin recordatorio'
+      task.reminderAt ? frequencyLabels[task.frequency] : 'Sin recordatorio'
     }`
 
     return [

--- a/helpers/frequency/flowFrequency/interactiveFlowFrequency.js
+++ b/helpers/frequency/flowFrequency/interactiveFlowFrequency.js
@@ -1,4 +1,5 @@
 import { Markup } from 'telegraf'
+import { frequencyLabels } from '../frequencyLabels.js'
 
 /**
  * Construye texto y teclado inline para la clasificación de periodicidad.
@@ -6,12 +7,10 @@ import { Markup } from 'telegraf'
  */
 export const buildFrequencyMenu = () => {
   const text = '¿Con qué periodicidad quieres esta tarea?'
-  const options = [
-    { label: 'Diario', value: 'daily' },
-    { label: 'Semanal', value: 'weekly' },
-    { label: 'Mensual', value: 'monthly' },
-    { label: 'Anual', value: 'yearly' }
-  ]
+  const options = Object.entries(frequencyLabels).map(([value, label]) => ({
+    label,
+    value
+  }))
   const inline = Markup.inlineKeyboard(
     options.map((o) => [
       Markup.button.callback(o.label, `add_freq_${o.value}`)

--- a/helpers/frequency/frequencyLabels.js
+++ b/helpers/frequency/frequencyLabels.js
@@ -1,0 +1,6 @@
+export const frequencyLabels = {
+  daily: 'Diario',
+  weekly: 'Semanal',
+  monthly: 'Mensual',
+  yearly: 'Anual'
+}

--- a/test/unit/actions/reminderAction/startReminderAction.test.js
+++ b/test/unit/actions/reminderAction/startReminderAction.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { startReminderAction } from '@/actions/reminderAction/startReminderAction.js'
-import { getActiveTasksByUser } from '@/helpers/taskHelpers/edit/taskSelection.js'
+import { findAllTasks } from '@/helpers/tasks/findAllTasks.js'
 
-vi.mock('@/helpers/taskHelpers/edit/taskSelection.js', () => ({
-  getActiveTasksByUser: vi.fn()
+vi.mock('@/helpers/tasks/findAllTasks.js', () => ({
+  findAllTasks: vi.fn()
 }))
 
 describe('startReminderAction', () => {
@@ -15,14 +15,14 @@ describe('startReminderAction', () => {
 
   it('lists tasks with current frequency labels', async () => {
     const now = new Date()
-    getActiveTasksByUser.mockResolvedValue([
+    findAllTasks.mockResolvedValue([
       { _id: '1', name: 'Task 1', reminderAt: now, frequency: 'daily' },
       { _id: '2', name: 'Task 2', reminderAt: null, frequency: 'weekly' }
     ])
 
     await startReminderAction(ctx)
 
-    expect(getActiveTasksByUser).toHaveBeenCalledWith(1)
+    expect(findAllTasks).toHaveBeenCalledWith(1)
     expect(ctx.reply).toHaveBeenCalledWith(
       'Selecciona una tarea para configurar su recordatorio:',
       {


### PR DESCRIPTION
## Summary
- centralize spanish frequency labels in new helper
- reuse helper in reminder actions
- update unit tests to mock new helper path

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684747796fd4832087b4fd06e6f7bf51