### PR TITLE
Improve reminder flow session tracking

### DIFF
--- a/actions/reminderAction/saveReminderAction.js
+++ b/actions/reminderAction/saveReminderAction.js
@@ -36,6 +36,9 @@ export const saveReminderAction = async (ctx) => {
   await task.save()
   await ctx.answerCbQuery()
 
+  ctx.session.flowType = null
+  delete ctx.session.menuMessageId
+
   return flashReply(
     ctx,
     `Se ha configurado el recordatorio para la tarea "${task.name}" con frecuencia "${frequency}".`,

--- a/actions/reminderAction/startReminderAction.js
+++ b/actions/reminderAction/startReminderAction.js
@@ -4,10 +4,12 @@ import { findAllTasks } from '../../helpers/tasks/findAllTasks.js'
 import { safeReply } from '../../utils/retryUtils/safeReply.js'
 
 export const startReminderAction = async (ctx) => {
+  ctx.session.flowType = 'reminder'
   const userId = ctx.from.id
   const tasks = await findAllTasks(userId)
 
   if (!tasks.length) {
+    ctx.session.flowType = null
     return safeReply(
       ctx,
       '😕 No tienes tareas activas para configurar recordatorios.'
@@ -34,9 +36,14 @@ export const startReminderAction = async (ctx) => {
     ]
   })
 
-  return ctx.reply('Selecciona una tarea para configurar su recordatorio:', {
-    reply_markup: {
-      inline_keyboard: buttons
+  const msg = await ctx.reply(
+    'Selecciona una tarea para configurar su recordatorio:',
+    {
+      reply_markup: {
+        inline_keyboard: buttons
+      }
     }
-  })
+  )
+  ctx.session.menuMessageId = msg.message_id
+  return msg
 }

--- a/middlewares/flowControl/flowGuard.js
+++ b/middlewares/flowControl/flowGuard.js
@@ -49,6 +49,11 @@ export async function flowGuard(ctx, next) {
           return next()
         }
         break
+      case 'reminder':
+        if (/^(setReminder|saveReminder)::/.test(cb)) {
+          return next()
+        }
+        break
       case 'timezone':
         // permitir tanto el menú inicial como la confirmación
         if (/^(set_tz_|confirm_tz_)/.test(cb)) {

--- a/test/unit/actions/reminderAction/saveReminderAction.test.js
+++ b/test/unit/actions/reminderAction/saveReminderAction.test.js
@@ -12,7 +12,11 @@ vi.mock('@/utils/delayUtils/flashReply.js', () => ({
 }))
 
 describe('saveReminderAction', () => {
-  const ctx = { callbackQuery: { data: 'saveReminder::100::weekly' }, answerCbQuery: vi.fn() }
+  const ctx = {
+    callbackQuery: { data: 'saveReminder::100::weekly' },
+    answerCbQuery: vi.fn(),
+    session: { flowType: 'reminder', menuMessageId: 1 }
+  }
 
   beforeEach(() => {
     vi.useFakeTimers()
@@ -51,5 +55,7 @@ describe('saveReminderAction', () => {
       {},
       2500
     )
+    expect(ctx.session.flowType).toBeNull()
+    expect(ctx.session.menuMessageId).toBeUndefined()
   })
 })

--- a/test/unit/actions/reminderAction/startReminderAction.test.js
+++ b/test/unit/actions/reminderAction/startReminderAction.test.js
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { startReminderAction } from '@/actions/reminderAction/startReminderAction.js'
-import { getActiveTasksByUser } from '@/helpers/taskHelpers/edit/taskSelection.js'
+import { findAllTasks } from '@/helpers/tasks/findAllTasks.js'
 
-vi.mock('@/helpers/taskHelpers/edit/taskSelection.js', () => ({
-  getActiveTasksByUser: vi.fn()
+vi.mock('@/helpers/tasks/findAllTasks.js', () => ({
+  findAllTasks: vi.fn()
 }))
 
 describe('startReminderAction', () => {
-  const ctx = { from: { id: 1 }, reply: vi.fn() }
+  const ctx = {
+    from: { id: 1 },
+    reply: vi.fn(() => ({ message_id: 99 })),
+    session: {}
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -15,14 +19,14 @@ describe('startReminderAction', () => {
 
   it('lists tasks with current frequency labels', async () => {
     const now = new Date()
-    getActiveTasksByUser.mockResolvedValue([
+    findAllTasks.mockResolvedValue([
       { _id: '1', name: 'Task 1', reminderAt: now, frequency: 'daily' },
       { _id: '2', name: 'Task 2', reminderAt: null, frequency: 'weekly' }
     ])
 
     await startReminderAction(ctx)
 
-    expect(getActiveTasksByUser).toHaveBeenCalledWith(1)
+    expect(findAllTasks).toHaveBeenCalledWith(1)
     expect(ctx.reply).toHaveBeenCalledWith(
       'Selecciona una tarea para configurar su recordatorio:',
       {
@@ -34,5 +38,7 @@ describe('startReminderAction', () => {
         }
       }
     )
+    expect(ctx.session.flowType).toBe('reminder')
+    expect(ctx.session.menuMessageId).toBeDefined()
   })
 })


### PR DESCRIPTION
## Summary
- track reminder flow state and menu message
- clear reminder flow state once saved
- allow reminder callbacks through flowGuard middleware
- test reminder session updates

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847477cdbd08320b6dcdc2158f1687b