### PR TITLE
Fix reminder action test helper

### DIFF
--- a/test/unit/actions/reminderAction/startReminderAction.test.js
+++ b/test/unit/actions/reminderAction/startReminderAction.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { startReminderAction } from '@/actions/reminderAction/startReminderAction.js'
-import { getActiveTasksByUser } from '@/helpers/taskHelpers/edit/taskSelection.js'
+import { findAllTasks } from '@/helpers/tasks/findAllTasks.js'
 
-vi.mock('@/helpers/taskHelpers/edit/taskSelection.js', () => ({
-  getActiveTasksByUser: vi.fn()
+vi.mock('@/helpers/tasks/findAllTasks.js', () => ({
+  findAllTasks: vi.fn()
 }))
 
 describe('startReminderAction', () => {
@@ -15,14 +15,14 @@ describe('startReminderAction', () => {
 
   it('lists tasks with current frequency labels', async () => {
     const now = new Date()
-    getActiveTasksByUser.mockResolvedValue([
+    findAllTasks.mockResolvedValue([
       { _id: '1', name: 'Task 1', reminderAt: now, frequency: 'daily' },
       { _id: '2', name: 'Task 2', reminderAt: null, frequency: 'weekly' }
     ])
 
     await startReminderAction(ctx)
 
-    expect(getActiveTasksByUser).toHaveBeenCalledWith(1)
+    expect(findAllTasks).toHaveBeenCalledWith(1)
     expect(ctx.reply).toHaveBeenCalledWith(
       'Selecciona una tarea para configurar su recordatorio:',
       {


### PR DESCRIPTION
## Summary
- mock the correct helper for `startReminderAction`

## Testing
- `npx vitest run` *(fails: 403 Forbidden when trying to download vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6847478c47b08320be5d3212b20f6450