### PR TITLE
Add reminder flow session updates and tests

### DIFF
--- a/actions/reminderAction/saveReminderAction.js
+++ b/actions/reminderAction/saveReminderAction.js
@@ -1,5 +1,6 @@
 import { Task } from '../../models/task.js'
 import { flashReply } from '../../utils/delayUtils/flashReply.js'
+import { safeAnswerCbQuery } from '../../utils/retryUtils/safeAnswerCbQuery.js'
 
 const addIntervalToNow = (frequency) => {
   const now = new Date()
@@ -26,7 +27,7 @@ export const saveReminderAction = async (ctx) => {
 
   const task = await Task.findById(taskId)
   if (!task) {
-    return ctx.answerCbQuery('Tarea no encontrada.')
+    return safeAnswerCbQuery(ctx, 'Tarea no encontrada.')
   }
 
   task.frequency = frequency
@@ -34,7 +35,10 @@ export const saveReminderAction = async (ctx) => {
   task.alertsSent = [] // Resetea las alertas pasadas
 
   await task.save()
-  await ctx.answerCbQuery()
+  await safeAnswerCbQuery(ctx)
+
+  ctx.session.flowType = null
+  delete ctx.session.menuMessageId
 
   return flashReply(
     ctx,

--- a/actions/reminderAction/startReminderAction.js
+++ b/actions/reminderAction/startReminderAction.js
@@ -34,9 +34,17 @@ export const startReminderAction = async (ctx) => {
     ]
   })
 
-  return ctx.reply('Selecciona una tarea para configurar su recordatorio:', {
-    reply_markup: {
-      inline_keyboard: buttons
+  const msg = await ctx.reply(
+    'Selecciona una tarea para configurar su recordatorio:',
+    {
+      reply_markup: {
+        inline_keyboard: buttons
+      }
     }
-  })
+  )
+
+  ctx.session.flowType = 'reminder'
+  ctx.session.menuMessageId = msg.message_id
+
+  return msg
 }

--- a/events/reminderEvent/handleReminderFrequency.js
+++ b/events/reminderEvent/handleReminderFrequency.js
@@ -11,7 +11,7 @@ export const handleReminderFrequency = async (ctx) => {
     return ctx.answerCbQuery('Tarea no encontrada.')
   }
 
-  const { markup } = buildFrequencyMenu()
+  const { text, markup } = buildFrequencyMenu()
   const frequencyOptions = markup.reply_markup.inline_keyboard.map((row) => {
     const button = row[0]
     const value = button.callback_data.replace('add_freq_', '')
@@ -24,6 +24,12 @@ export const handleReminderFrequency = async (ctx) => {
   })
 
   await ctx.answerCbQuery()
+
+  try {
+    await ctx.editMessageText(text, markup)
+  } catch {
+    await ctx.reply(text, markup)
+  }
 
   return safeEditMessageReplyMarkup(ctx, {
     reply_markup: {

--- a/test/unit/actions/reminderAction/handleReminderFrequency.test.js
+++ b/test/unit/actions/reminderAction/handleReminderFrequency.test.js
@@ -17,10 +17,17 @@ vi.mock('@/utils/retryUtils/safeEditMessageReplyMarkup.js', () => ({
 }))
 
 describe('handleReminderFrequency', () => {
-  const ctx = { callbackQuery: { data: 'setReminder::42' }, answerCbQuery: vi.fn() }
+  const ctx = {
+    callbackQuery: { data: 'setReminder::42' },
+    answerCbQuery: vi.fn(),
+    editMessageText: vi.fn(),
+    reply: vi.fn()
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
+    ctx.editMessageText.mockReset()
+    ctx.reply.mockReset()
   })
 
   it('shows the keyboard returned by buildFrequencyMenu', async () => {
@@ -48,6 +55,20 @@ describe('handleReminderFrequency', () => {
           [{ text: 'Semanal', callback_data: 'saveReminder::42::weekly' }]
         ]
       }
+    })
+  })
+
+  it('edits the message text using the menu text', async () => {
+    Task.findById.mockResolvedValue({ _id: '42', name: 'Task' })
+    buildFrequencyMenu.mockReturnValue({
+      text: 'msg',
+      markup: { reply_markup: { inline_keyboard: [] } }
+    })
+
+    await handleReminderFrequency(ctx)
+
+    expect(ctx.editMessageText).toHaveBeenCalledWith('msg', {
+      reply_markup: { inline_keyboard: [] }
     })
   })
 })

--- a/test/unit/actions/reminderAction/saveReminderAction.test.js
+++ b/test/unit/actions/reminderAction/saveReminderAction.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { saveReminderAction } from '@/actions/reminderAction/saveReminderAction.js'
 import { Task } from '@/models/task.js'
 import { flashReply } from '@/utils/delayUtils/flashReply.js'
+import { safeAnswerCbQuery } from '@/utils/retryUtils/safeAnswerCbQuery.js'
 
 vi.mock('@/models/task.js', () => ({
   Task: { findById: vi.fn() }
@@ -11,13 +12,22 @@ vi.mock('@/utils/delayUtils/flashReply.js', () => ({
   flashReply: vi.fn()
 }))
 
+vi.mock('@/utils/retryUtils/safeAnswerCbQuery.js', () => ({
+  safeAnswerCbQuery: vi.fn()
+}))
+
 describe('saveReminderAction', () => {
-  const ctx = { callbackQuery: { data: 'saveReminder::100::weekly' }, answerCbQuery: vi.fn() }
+  const ctx = {
+    callbackQuery: { data: 'saveReminder::100::weekly' },
+    answerCbQuery: vi.fn(),
+    session: {}
+  }
 
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2024-01-01T00:00:00Z'))
     vi.clearAllMocks()
+    ctx.session = {}
   })
 
   afterEach(() => {
@@ -44,12 +54,14 @@ describe('saveReminderAction', () => {
     )
     expect(task.alertsSent).toEqual([])
     expect(saveMock).toHaveBeenCalled()
-    expect(ctx.answerCbQuery).toHaveBeenCalled()
+    expect(safeAnswerCbQuery).toHaveBeenCalled()
     expect(flashReply).toHaveBeenCalledWith(
       ctx,
       expect.stringContaining('My task'),
       {},
       2500
     )
+    expect(ctx.session.flowType).toBeNull()
+    expect(ctx.session.menuMessageId).toBeUndefined()
   })
 })

--- a/test/unit/actions/reminderAction/startReminderAction.test.js
+++ b/test/unit/actions/reminderAction/startReminderAction.test.js
@@ -1,28 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { startReminderAction } from '@/actions/reminderAction/startReminderAction.js'
-import { getActiveTasksByUser } from '@/helpers/taskHelpers/edit/taskSelection.js'
+import { findAllTasks } from '@/helpers/tasks/findAllTasks.js'
 
-vi.mock('@/helpers/taskHelpers/edit/taskSelection.js', () => ({
-  getActiveTasksByUser: vi.fn()
+vi.mock('@/helpers/tasks/findAllTasks.js', () => ({
+  findAllTasks: vi.fn()
 }))
 
 describe('startReminderAction', () => {
-  const ctx = { from: { id: 1 }, reply: vi.fn() }
+  const ctx = { from: { id: 1 }, reply: vi.fn(), session: {} }
 
   beforeEach(() => {
     vi.clearAllMocks()
+    ctx.session = {}
   })
 
   it('lists tasks with current frequency labels', async () => {
     const now = new Date()
-    getActiveTasksByUser.mockResolvedValue([
+    findAllTasks.mockResolvedValue([
       { _id: '1', name: 'Task 1', reminderAt: now, frequency: 'daily' },
       { _id: '2', name: 'Task 2', reminderAt: null, frequency: 'weekly' }
     ])
 
     await startReminderAction(ctx)
 
-    expect(getActiveTasksByUser).toHaveBeenCalledWith(1)
+    expect(findAllTasks).toHaveBeenCalledWith(1)
     expect(ctx.reply).toHaveBeenCalledWith(
       'Selecciona una tarea para configurar su recordatorio:',
       {
@@ -34,5 +35,15 @@ describe('startReminderAction', () => {
         }
       }
     )
+  })
+
+  it('stores flow info and menu message id', async () => {
+    findAllTasks.mockResolvedValue([{ _id: '1', name: 'Task', reminderAt: null, frequency: 'daily' }])
+    ctx.reply.mockResolvedValue({ message_id: 99 })
+
+    await startReminderAction(ctx)
+
+    expect(ctx.session.flowType).toBe('reminder')
+    expect(ctx.session.menuMessageId).toBe(99)
   })
 })


### PR DESCRIPTION
## Summary
- store flow type and message ID when starting reminder flow
- edit message text when selecting reminder frequency
- clear session after saving reminder and answer callback safely
- extend tests for reminder actions

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684747956e78832082ea0e8d45fe8a2a